### PR TITLE
Allow using other versions of the apps API group in the deployment

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.2.1
+version: 0.2.2
 apiVersion: v1
 appVersion: 2.2
 description: A reverse proxy that provides authentication with Google, Github or other providers

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/{{ .Values.deploymentApiVersion }}
 kind: Deployment
 metadata:
   labels:

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -19,6 +19,10 @@ image:
 # imagePullSecrets:
   # - name: myRegistryKeySecretName
 
+# API group version to use in the deployment object. This allows using this
+# chart in versions of k8s with compatible versions of the apps/ API group
+deploymentApiVersion: v1beta2
+
 extraArgs:
   email-domain: "*"
   upstream: "file:///dev/null"


### PR DESCRIPTION
**What this PR does / why we need it**:

Motivation: It enables installing this chart in k8s 1.7.x

It adds a values parameter named `deploymentApiVersion` and uses it when generating the deployment.
