### PR TITLE
Use supported apps API group version in the deployment

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.2.1
+version: 0.2.2
 apiVersion: v1
 appVersion: 2.2
 description: A reverse proxy that provides authentication with Google, Github or other providers

--- a/stable/oauth2-proxy/templates/_helpers.tpl
+++ b/stable/oauth2-proxy/templates/_helpers.tpl
@@ -30,3 +30,18 @@ Create chart name and version as used by the chart label.
 {{- define "oauth2-proxy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Get the most recent version for the apps API group.
+*/}}
+{{- define "oauth2-proxy.appsAPIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "apps/v1beta2" -}}
+apps/v1beta2
+{{- else if .Capabilities.APIVersions.Has "apps/v1beta1" -}}
+apps/v1beta1
+{{- else -}}
+{{- required "The target cluster does not have the supported apps API version" nil }}
+{{- end -}}
+{{- end -}}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: {{ include "oauth2-proxy.appsAPIVersion" . }}
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
**What this PR does / why we need it:**

Motivation: It enables installing this chart in k8s that support other versions of the apps API group

Defines and uses a helper template to get the most recent apps API version supported by the cluster.
