### PR TITLE
Create default profile during kanister install

### DIFF
--- a/stable/kanister-operator/templates/profile.yaml
+++ b/stable/kanister-operator/templates/profile.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.profile.create_profile }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,11 +11,11 @@ data:
 apiVersion: cr.kanister.io/v1alpha1
 kind: Profile
 metadata:
-  name: {{ template "kanister-operator.fullname" . }}-profile
+  name: default-profile
 location:
   type: s3Compliant
   s3Compliant:
-    bucket: {{ required "S3 compatible bucket is required when configuring a profile." .Values.profile.location.s3_bucket |  quote }}
+    bucket: {{ required "S3 compatible bucket is required when configuring a profile." .Values.profile.location.s3_bucket | quote }}
     endpoint: {{ .Values.profile.location.s3_endpoint | quote }}
     prefix: {{ .Values.profile.location.s3_prefix | quote }}
     region: {{ .Values.profile.location.s3_region | quote }}
@@ -28,3 +29,4 @@ credential:
       kind: Secret
       name: {{ template "kanister-operator.fullname" . }}-profile-creds
 skipSSLVerify: {{ .Values.profile.s3_verify_ssl }}
+{{- end }}

--- a/stable/kanister-operator/templates/profile.yaml
+++ b/stable/kanister-operator/templates/profile.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kanister-operator.fullname" . }}-profile-creds
+type: Opaque
+data:
+  aws_access_key_id: {{ required "Cloud provider API key is required when configuring a profile." .Values.profile.creds.s3_api_key | b64enc | quote }}
+  aws_secret_access_key: {{ required "Cloud provider API secret is required when configuring a profile." .Values.profile.creds.s3_api_secret | b64enc | quote }}
+---
+apiVersion: cr.kanister.io/v1alpha1
+kind: Profile
+metadata:
+  name: {{ template "kanister-operator.fullname" . }}-profile
+location:
+  type: s3Compliant
+  s3Compliant:
+    bucket: {{ required "S3 compatible bucket is required when configuring a profile." .Values.profile.location.s3_bucket |  quote }}
+    endpoint: {{ .Values.profile.location.s3_endpoint | quote }}
+    prefix: {{ .Values.profile.location.s3_prefix | quote }}
+    region: {{ .Values.profile.location.s3_region | quote }}
+credential:
+  type: keyPair
+  keyPair:
+    idField: aws_access_key_id
+    secretField: aws_secret_access_key
+    secret:
+      apiVersion: v1
+      kind: Secret
+      name: {{ template "kanister-operator.fullname" . }}-profile-creds
+skipSSLVerify: {{ .Values.profile.s3_verify_ssl }}

--- a/stable/kanister-operator/values.yaml
+++ b/stable/kanister-operator/values.yaml
@@ -5,6 +5,16 @@ image:
   repository: kanisterio/controller
   tag: v0.2.0
   pullPolicy: IfNotPresent
+profile:
+  s3_verify_ssl: true
+  creds:
+    s3_api_key:
+    s3_api_secret:
+  location:
+    s3_bucket:
+    s3_endpoint:
+    s3_prefix:
+    s3_region:
 rbac:
   create: true
 serviceAccount:

--- a/stable/kanister-operator/values.yaml
+++ b/stable/kanister-operator/values.yaml
@@ -6,6 +6,7 @@ image:
   tag: v0.2.0
   pullPolicy: IfNotPresent
 profile:
+  create_profile: false
   s3_verify_ssl: true
   creds:
     s3_api_key:


### PR DESCRIPTION
Allows users to create a default profile to use at install time.

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Add a profile by default during the installation of kanister-operator

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**: This is just an initial commit. I have run the chart on our local kubernetes shared cluster. 
